### PR TITLE
Improve client index consistency in debug mode

### DIFF
--- a/extensions/MultiClient/multiclient.yy
+++ b/extensions/MultiClient/multiclient.yy
@@ -15,6 +15,7 @@
     {"resourceType":"GMExtensionOption","resourceVersion":"1.0","name":"Should_Proxy_Clients","extensionId":null,"guid":"b29b41e4-3d53-4a72-b082-0eb3d51bd81d","displayName":"Proxy subsequent clients","listItems":[],"description":"Should subsequent clients be ran through a proxy? (Sandboxie etc)","defaultValue":"False","exportToINI":false,"hidden":false,"optType":0,},
     {"resourceType":"GMExtensionOption","resourceVersion":"1.0","name":"Proxy_Path","extensionId":null,"guid":"ab4971c8-45fa-4411-a982-e16a3af58307","displayName":"Proxy path","listItems":[],"description":"What application should be used to proxy ","defaultValue":"","exportToINI":false,"hidden":false,"optType":3,},
     {"resourceType":"GMExtensionOption","resourceVersion":"1.0","name":"Proxy_Args","extensionId":null,"guid":"e61f4ac7-53ac-46e2-b0c8-a949f1acd862","displayName":"Proxy arguments","listItems":[],"description":"Arguments for your proxy (/box:<boxName> for Sandboxie for instance)\r\nArgs for each client are separated by semicolons\r\n(example: -client2Args;-client3Args;-client4Args )","defaultValue":"","exportToINI":false,"hidden":false,"optType":2,},
+    {"resourceType":"GMExtensionOption","resourceVersion":"1.0","name":"Search_Port","extensionId":null,"guid":"f506fe0e-5a82-4155-8b2a-69e6e6053844","displayName":"Debug mode search port","listItems":[],"description":"","defaultValue":"19839","exportToINI":false,"hidden":false,"optType":1,},
   ],
   "exportToGame": true,
   "supportedTargets": -1,

--- a/extensions/MultiClient/post_run_step.bat
+++ b/extensions/MultiClient/post_run_step.bat
@@ -64,9 +64,9 @@ for /l %%x in (1, %MaxClients%, %NumOfInsts%) do (
         if %ShouldProxyClients% EQU True (
             if !n_clients! EQU 0 (
                 if %YYTARGET_runtime% EQU YYC (
-                    start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                    start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
                 ) else (
-                    start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                    start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
                 )
             ) else (
                 set token=""
@@ -80,16 +80,16 @@ for /l %%x in (1, %MaxClients%, %NumOfInsts%) do (
                 )
                 echo Proxying client !n_clients!
                 if %YYTARGET_runtime% EQU YYC (
-                    "%ProxyPath%" !token!"%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                    "%ProxyPath%" !token!"%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x —mc-client-number %MaxClients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
                 ) else (
-                    "%ProxyPath%" !token!%YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                    "%ProxyPath%" !token!%YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
                 )
             )
         ) else (
             if %YYTARGET_runtime% EQU YYC (
-                start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x -mc-client-number %MaxClients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
             ) else (
-                start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x %YYEXTOPT_MultiClient_Additional_Parameters%
+                start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
             )
         )
 	)

--- a/objects/obj_test/Draw_0.gml
+++ b/objects/obj_test/Draw_0.gml
@@ -1,4 +1,7 @@
 /// @description Insert description here
 // You can write your code in this editor
 
-draw_text(32,32, "I am " + string(window_num));
+var _string = "I am " + string(window_num);
+repeat((current_time mod 1000) div 250) _string += ".";
+
+draw_text(32, 32, _string);

--- a/options/extensions/MultiClient.json
+++ b/options/extensions/MultiClient.json
@@ -29,6 +29,11 @@
     "6d5b035c-3696-4554-a0e9-819187ea6303": null,
     "b29b41e4-3d53-4a72-b082-0eb3d51bd81d": null,
     "ab4971c8-45fa-4411-a982-e16a3af58307": null,
-    "e61f4ac7-53ac-46e2-b0c8-a949f1acd862": null
+    "e61f4ac7-53ac-46e2-b0c8-a949f1acd862": null,
+    "f506fe0e-5a82-4155-8b2a-69e6e6053844": {
+      "Default": {
+        "value": "19839"
+      }
+    }
   }
 }

--- a/scripts/MultiClientGetID/MultiClientGetID.gml
+++ b/scripts/MultiClientGetID/MultiClientGetID.gml
@@ -23,12 +23,53 @@ function MultiClientGetID(){
 					++_i;
 				}
 			} else {
-				repeat(parameter_count()) {
-					if (parameter_string(_i) == "mc-window-number") {
-						_num = real(parameter_string(_i+1))-1;
-						break;
+				if (debug_mode) {
+					// extract the total number of clients and the search port from the extension
+					// this works around the native extension_*() functions not working in LTS
+					var _clientNumber = undefined;
+					var _searchPort   = undefined;
+					
+					repeat(parameter_count()) {
+						if (parameter_string(_i) == "mc-client-number") {
+							_clientNumber = real(parameter_string(_i+1));
+						}
+						
+						if (parameter_string(_i) == "mc-search-port") {
+							_searchPort = real(parameter_string(_i+1));
+						}
+						
+						++_i;
 					}
-					++_i;
+					
+					// use sockets as a way to count how many windows have been initialized
+					var _i = 0;
+					repeat(_clientNumber) {
+						var _socket = network_create_socket_ext(network_socket_tcp, _searchPort);
+						if (_socket >= 0) {
+							// ensure that the last client created has an index of 0
+							// the last client created is the one that'll connect to the debugger
+							// this means that client index 0 will be the "main" instance hooked up to the debugger
+							_num = (_clientNumber-1) - _i;
+							
+							// destroy this socket after a second
+							call_later(1000, time_source_units_seconds, method({
+								__socket: _socket,
+							}, function() {
+								network_destroy(__socket);
+							}));
+							break;
+						}
+						++_i;
+						++_searchPort;
+					}
+				} else {
+					repeat(parameter_count()) {
+						if (parameter_string(_i) == "mc-window-number") {
+							_num = real(parameter_string(_i+1))-1;
+							break;
+						}
+						++_i;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When running in debug mode (with the debug mode compatibility option turned on), one would expect the client indexes to be `0` and `1` to match non-debug mode. However, I found that (on Windows at least) the client indexes of successfully opened windows can vary a lot. For example, for two clients, you might receive indexes of `0` and `7` or `1` and `2`. It further seems like the highest index client is the one that typically connectes to the debugger. This makes it hard to debug MultiClient projects.

This PR addresses the inconsistency in client indexes by using networking sockets to allow clients to detect the presence of other clients. This works by creating sockets that we expect to fail to be created. When we fail then we increment the socket port and try again. We continue to do this until we create a socket successfully which tells us how many client already exist. A successfully created socket is destroyed 1 second later to avoid leaving it open unnecessarily. We then convert the number of open clients such that the last client to be created is index 0, thus ensuring that index 0 is always the instance that is connected to the debugger regardless of the number of clients that exist.

Due to bugs in LTS (I think?), the native `extension_*()` functions fail. This means the number of clients and the starting port have to be routed through the batch file and into the executable parameters. This sucks, and when this utility is updated to a more recent version of GameMaker this should be addressed.