### PR TITLE
Remove erroneous double quote that breaks parameters

### DIFF
--- a/extensions/MultiClient/post_run_step.bat
+++ b/extensions/MultiClient/post_run_step.bat
@@ -71,9 +71,9 @@ for /l %%x in (1, %MaxClients%, %NumOfInsts%) do (
         if %ShouldProxyClients% EQU True (
             if !n_clients! EQU 0 (
                 if %YYTARGET_runtime% EQU YYC (
-                    start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
+                    start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port% %YYEXTOPT_MultiClient_Additional_Parameters%
                 ) else (
-                    start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
+                    start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port% %YYEXTOPT_MultiClient_Additional_Parameters%
                 )
             ) else (
                 set token=""
@@ -89,14 +89,14 @@ for /l %%x in (1, %MaxClients%, %NumOfInsts%) do (
                 if %YYTARGET_runtime% EQU YYC (
                     "%ProxyPath%" !token!"%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x —mc-client-number %MaxClients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
                 ) else (
-                    "%ProxyPath%" !token!%YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
+                    "%ProxyPath%" !token!%YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port% %YYEXTOPT_MultiClient_Additional_Parameters%
                 )
             )
         ) else (
             if %YYTARGET_runtime% EQU YYC (
                 start /b cmd /C "%YYoutputFolder%\%YYprojectName%.exe" —mc-window-number %%x -mc-client-number %MaxClients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
             ) else (
-                start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port%" %YYEXTOPT_MultiClient_Additional_Parameters%
+                start /b cmd /C %YYruntimeLocation%\Windows\x64\runner.exe -game "%YYoutputFolder%\%YYprojectName%.win" —mc-window-number %%x —mc-client-number %YYEXTOPT_MultiClient_Number_Of_Clients% —mc-search-port %YYEXTOPT_MultiClient_Search_Port% %YYEXTOPT_MultiClient_Additional_Parameters%
             )
         )
 	)


### PR DESCRIPTION
There seems to be an extra double quote just after the value for mc-search-port when passing parameters to the runner, which causes GM to fail to properly parse additional parameters for the parameter_string function

Before removal:

![image](https://github.com/user-attachments/assets/a9eab812-5e44-4e27-891c-84ce53c32afe)

After:

![image](https://github.com/user-attachments/assets/0c1823fc-020c-4b9b-bedb-63da12f652e7)
